### PR TITLE
feat(auth): add OIDC authentication support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 VITE_API_BASE_URL= # Base URL of the API, e.g., https://example.com/api
 VITE_INCLUDE_CREDENTIALS=false # Set to true to enable login screen and include credentials in requests, or false to disable it
+AUTH_MODE=token # Authentication mode: "token" (default, legacy Bearer flow) or "oidc" (OpenID Connect cookie-based flow)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,8 @@ set -e
 cat <<EOF > /app/config.json
 {
   "API_BASE_URL": "${API_BASE_URL}",
-  "INCLUDE_CREDENTIALS": ${INCLUDE_CREDENTIALS:-false}
+  "INCLUDE_CREDENTIALS": ${INCLUDE_CREDENTIALS:-false},
+  "AUTH_MODE": "${AUTH_MODE:-token}"
 }
 EOF
 

--- a/src/lib/api/dashboard.ts
+++ b/src/lib/api/dashboard.ts
@@ -1,6 +1,5 @@
-// Base URL and auth token
-import { getApiBaseUrl } from "./index";
-import { authToken } from "$lib/persisted.svelte";
+// Base URL and auth helpers
+import { getApiBaseUrl, authFetch } from "./index";
 
 
 /**
@@ -8,11 +7,7 @@ import { authToken } from "$lib/persisted.svelte";
  */
 export const fetchActors = async () => {
     console.log("Fetching actors...");
-    const response = await fetch(`${getApiBaseUrl()}/actors/`, {
-        headers: {
-            Authorization: `Bearer ${authToken.current}`,
-        },
-    });
+    const response = await authFetch(`${getApiBaseUrl()}/actors/`);
 
     if (!response.ok) {
         throw new Error(`Failed to fetch actors: ${response.status} ${response.statusText}`);
@@ -26,11 +21,8 @@ export const fetchActors = async () => {
 
 export const restartActor = async (actor_name: string) => {
     console.log(`Restarting actor ${actor_name}...`);
-    const response = await fetch(`${getApiBaseUrl()}/actors/${actor_name}/restart`, {
+    const response = await authFetch(`${getApiBaseUrl()}/actors/${actor_name}/restart`, {
         method: "POST",
-        headers: {
-            Authorization: `Bearer ${authToken.current}`,
-        },
     });
 
     if (!response.ok) {

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -3,9 +3,10 @@ const normalizeUrl = (url: string): string => {
     return url.endsWith("/") ? url.slice(0, -1) : url;
 };
 
-// Retrieve the API base URL and credentials flag from dynamic config
+// Retrieve the API base URL, credentials flag and auth mode from dynamic config
 let API_BASE_URL = "";
 let INCLUDE_CREDENTIALS = false;
+let AUTH_MODE: "token" | "oidc" = "token";
 
 export function getApiBaseUrl() {
     return API_BASE_URL;
@@ -15,17 +16,69 @@ export function getIncludeCredentials() {
     return INCLUDE_CREDENTIALS;
 }
 
+export function getAuthMode() {
+    return AUTH_MODE;
+}
+
+export function isOidcMode() {
+    return AUTH_MODE === "oidc";
+}
+
 export async function loadConfig() {
     const res = await fetch("/api/config");
     if (!res.ok) throw new Error("Failed to load config");
     const config = await res.json();
     API_BASE_URL = normalizeUrl(config.API_BASE_URL);
     INCLUDE_CREDENTIALS = !!config.INCLUDE_CREDENTIALS;
+    AUTH_MODE = config.AUTH_MODE === "oidc" ? "oidc" : "token";
 }
 
-export async function login(authToken: string): Promise<boolean> {
+/**
+ * Unified fetch wrapper that handles both auth modes.
+ * - token mode: sets Authorization: Bearer <localStorage token>
+ * - oidc mode: sends cookies via credentials: "include", handles 401/403 by redirecting to /auth/login
+ */
+export async function authFetch(input: string, init?: RequestInit): Promise<Response> {
+    const headers = new Headers(init?.headers);
+    const credentials: RequestCredentials =
+        AUTH_MODE === "oidc" || INCLUDE_CREDENTIALS ? "include" : "omit";
+
+    if (AUTH_MODE === "token") {
+        // Import dynamically to avoid a cycle with persisted.svelte
+        const { authToken } = await import("$lib/persisted.svelte");
+        if (authToken.current) {
+            headers.set("Authorization", `Bearer ${authToken.current}`);
+        }
+    }
+    // In oidc mode we do NOT set Authorization; the cookie authenticates us.
+
+    const response = await fetch(input, { ...init, headers, credentials });
+
+    // oidc auto-redirect on unauth
+    if (AUTH_MODE === "oidc" && (response.status === 401 || response.status === 403)) {
+        const next = encodeURIComponent(window.location.href);
+        window.location.href = `${API_BASE_URL}/auth/login?next=${next}`;
+        // Return a pending-forever response so callers don't see stale 401 data
+        return new Promise(() => {});
+    }
+
+    return response;
+}
+
+export async function login(authToken?: string): Promise<boolean> {
     console.log("Trying to log in...");
 
+    if (AUTH_MODE === "oidc") {
+        const response = await fetch(`${API_BASE_URL}/users/info`, {
+            credentials: "include",
+        });
+        if (response.ok) {
+            console.log("Log in successful (oidc).");
+        }
+        return response.ok;
+    }
+
+    // token mode: existing behaviour
     const response = await fetch(`${API_BASE_URL}/health_check`, {
         method: "GET",
         headers: {

--- a/src/lib/api/indexer.ts
+++ b/src/lib/api/indexer.ts
@@ -1,6 +1,5 @@
-// Base URL and auth token
-import { getApiBaseUrl } from "./index";
-import { authToken } from "$lib/persisted.svelte";
+// Base URL and auth helpers
+import { getApiBaseUrl, authFetch } from "./index";
 
 // Types
 import type {
@@ -19,11 +18,7 @@ import type {
  */
 export const fetchPartitions = async (): Promise<RAGPartition[]> => {
     console.log("Fetching partitions...");
-    const response = await fetch(`${getApiBaseUrl()}/partition/`, {
-        headers: {
-            Authorization: `Bearer ${authToken.current}`,
-        },
-    });
+    const response = await authFetch(`${getApiBaseUrl()}/partition/`);
 
     if (!response.ok) {
         throw new Error(`Failed to fetch partitions: ${response.status} ${response.statusText}`);
@@ -39,11 +34,9 @@ export const fetchPartitions = async (): Promise<RAGPartition[]> => {
  */
 export const fetchTasks = async (status?: RAGTaskStatus | "ACTIVE"): Promise<RAGTaskInList[]> => {
     console.log(`Fetching tasks${status ? ` with ${status} status` : ``}...`);
-    const response = await fetch(`${getApiBaseUrl()}/queue/tasks${status ? `?status=${status}` : ""}`, {
-        headers: {
-            Authorization: `Bearer ${authToken.current}`,
-        },
-    });
+    const response = await authFetch(
+        `${getApiBaseUrl()}/queue/tasks${status ? `?status=${status}` : ""}`
+    );
 
     if (!response.ok) {
         throw new Error(`Failed to fetch tasks: ${response.status} ${response.statusText}`);
@@ -59,11 +52,7 @@ export const fetchTasks = async (status?: RAGTaskStatus | "ACTIVE"): Promise<RAG
  */
 export const fetchTask = async (task: string): Promise<RAGTask> => {
     console.log(`Fetching task ${task}...`);
-    const response = await fetch(`${getApiBaseUrl()}/indexer/task/${task}`, {
-        headers: {
-            Authorization: `Bearer ${authToken.current}`,
-        },
-    });
+    const response = await authFetch(`${getApiBaseUrl()}/indexer/task/${task}`);
 
     if (!response.ok) {
         throw new Error(`Failed to fetch task: ${response.status} ${response.statusText}`);
@@ -79,11 +68,7 @@ export const fetchTask = async (task: string): Promise<RAGTask> => {
  */
 export const fetchFilesFromPartition = async (partition: string): Promise<RAGFileInList[]> => {
     console.log(`Fetching files from partition "${partition}"...`);
-    const response = await fetch(`${getApiBaseUrl()}/partition/${partition}`, {
-        headers: {
-            Authorization: `Bearer ${authToken.current}`,
-        },
-    });
+    const response = await authFetch(`${getApiBaseUrl()}/partition/${partition}`);
 
     if (!response.ok) {
         throw new Error(`Failed to fetch files: ${response.status} ${response.statusText}`);
@@ -99,11 +84,7 @@ export const fetchFilesFromPartition = async (partition: string): Promise<RAGFil
  */
 export const fetchFile = async (partition: string, file_id: string): Promise<RAGFile> => {
     console.log(`Fetching file "${file_id}" from partition "${partition}"...`);
-    const response = await fetch(`${getApiBaseUrl()}/partition/${partition}/file/${file_id}`, {
-        headers: {
-            Authorization: `Bearer ${authToken.current}`,
-        },
-    });
+    const response = await authFetch(`${getApiBaseUrl()}/partition/${partition}/file/${file_id}`);
 
     if (!response.ok) {
         throw new Error(`Failed to fetch file: ${response.status} ${response.statusText}`);
@@ -119,11 +100,7 @@ export const fetchFile = async (partition: string, file_id: string): Promise<RAG
  */
 export const fetchExtract = async (extract_id: string): Promise<RAGExtract> => {
     console.log(`Fetching extract "${extract_id}"...`);
-    const response = await fetch(`${getApiBaseUrl()}/extract/${extract_id}`, {
-        headers: {
-            Authorization: `Bearer ${authToken.current}`,
-        },
-    });
+    const response = await authFetch(`${getApiBaseUrl()}/extract/${extract_id}`);
 
     if (!response.ok) {
         throw new Error(`Failed to fetch extract: ${response.status} ${response.statusText}`);
@@ -139,11 +116,8 @@ export const fetchExtract = async (extract_id: string): Promise<RAGExtract> => {
  */
 export const deletePartition = async (partition: string): Promise<boolean> => {
     console.log(`Deleting partition "${partition}"...`);
-    const response = await fetch(`${getApiBaseUrl()}/partition/${partition}`, {
+    const response = await authFetch(`${getApiBaseUrl()}/partition/${partition}`, {
         method: "DELETE",
-        headers: {
-            Authorization: `Bearer ${authToken.current}`,
-        },
     });
 
     if (!response.ok) {
@@ -164,12 +138,10 @@ export const addFile = async (file: File, partition: string, file_id: string, me
     formData.append("file", file);
     if (metadata) formData.append("metadata", metadata);
 
-    const response = await fetch(`${getApiBaseUrl()}/indexer/partition/${partition}/file/${file_id}`, {
+    // multipart/form-data: do NOT set Content-Type; the browser sets the boundary.
+    const response = await authFetch(`${getApiBaseUrl()}/indexer/partition/${partition}/file/${file_id}`, {
         method: "POST",
         body: formData,
-        headers: {
-            Authorization: `Bearer ${authToken.current}`,
-        },
     });
 
     if (!response.ok) {
@@ -186,11 +158,8 @@ export const addFile = async (file: File, partition: string, file_id: string, me
  */
 export const deleteFile = async (partition: string, file_id: string): Promise<boolean> => {
     console.log(`Deleting file "${file_id}" from partition "${partition}"...`);
-    const response = await fetch(`${getApiBaseUrl()}/indexer/partition/${partition}/file/${file_id}`, {
+    const response = await authFetch(`${getApiBaseUrl()}/indexer/partition/${partition}/file/${file_id}`, {
         method: "DELETE",
-        headers: {
-            Authorization: `Bearer ${authToken.current}`,
-        },
     });
 
     if (!response.ok) {
@@ -206,11 +175,7 @@ export const deleteFile = async (partition: string, file_id: string): Promise<bo
  */
 export const fetchUserInfo = async (): Promise<UserInfo> => {
     console.log("Fetching user info...");
-    const response = await fetch(`${getApiBaseUrl()}/users/info`, {
-        headers: {
-            Authorization: `Bearer ${authToken.current}`,
-        },
-    });
+    const response = await authFetch(`${getApiBaseUrl()}/users/info`);
 
     if (!response.ok) {
         throw new Error(`Failed to fetch user info: ${response.status} ${response.statusText}`);

--- a/src/lib/components/layout/NavBar.svelte
+++ b/src/lib/components/layout/NavBar.svelte
@@ -21,6 +21,17 @@
         navbarCollapsed.current = !navbarCollapsed.current;
     }
 
+    function handleLogout() {
+        if (api.isOidcMode()) {
+            // oidc: invalidate backend session and end IdP SSO
+            window.location.href = `${api.getApiBaseUrl()}/auth/logout`;
+        } else {
+            authTokenCreatedAt.current = null; // Clear the Auth Token creation time
+            authToken.current = null; // Clear the Auth Token
+            window.location.reload(); // Reload the page to reset the states
+        }
+    }
+
     $effect(() => {
         handleRouting();
     });
@@ -92,19 +103,15 @@
             </a>
         </div>
 
-        {#if api.getIncludeCredentials()}
+        {#if api.getIncludeCredentials() || api.isOidcMode()}
             <div class="h-px w-8 mt-4 mb-3 bg-linagora-600"></div>
 
-            <!-- Lock access to the indexer -->
+            <!-- Lock access / Logout -->
             <button
-                title="Lock access"
+                title={api.isOidcMode() ? "Logout" : "Lock access"}
                 class="cursor-pointer group rounded-2xl p-2 font-medium text-linagora-900
             hover:bg-linagora-600 hover:text-linagora-950"
-                onclick={() => {
-                    authTokenCreatedAt.current = null; // Clear the Auth Token creation time
-                    authToken.current = null; // Clear the Auth Token
-                    window.location.reload(); // Reload the page to reset the states
-                }}
+                onclick={handleLogout}
             >
                 <Lock
                     className="size-6 fill-linagora-900 group-hover:fill-linagora-950"
@@ -198,23 +205,19 @@
             </a>
         </div>
 
-        {#if api.getIncludeCredentials()}
+        {#if api.getIncludeCredentials() || api.isOidcMode()}
             <div class="h-px mt-4 mb-3 bg-linagora-600"></div>
 
-            <!-- Lock access to the indexer -->
+            <!-- Lock access / Logout -->
             <button
                 class="cursor-pointer group flex items-center gap-2 rounded-2xl p-2 font-medium text-linagora-900
             hover:bg-linagora-600 hover:text-linagora-950"
-                onclick={() => {
-                    authTokenCreatedAt.current = null; // Clear the Auth Token creation time
-                    authToken.current = null; // Clear the Auth Token
-                    window.location.reload(); // Reload the page to reset the states
-                }}
+                onclick={handleLogout}
             >
                 <Lock
                     className="size-6 fill-linagora-900 group-hover:fill-linagora-950"
                 />
-                Lock access
+                {api.isOidcMode() ? "Logout" : "Lock access"}
             </button>
         {/if}
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -35,6 +35,26 @@
     onMount(async () => {
         await api.loadConfig();
 
+        if (api.isOidcMode()) {
+            // oidc mode: no login screen, check auth via /users/info
+            ui.showLoginPage = false; // never show the password form
+            try {
+                const ok = await api.login(); // checks /users/info with credentials: "include"
+                if (!ok) {
+                    const next = encodeURIComponent(window.location.href);
+                    window.location.href = `${api.getApiBaseUrl()}/auth/login?next=${next}`;
+                    return; // stop here, browser is navigating
+                }
+            } catch {
+                const next = encodeURIComponent(window.location.href);
+                window.location.href = `${api.getApiBaseUrl()}/auth/login?next=${next}`;
+                return;
+            }
+            loading = false;
+            return;
+        }
+
+        // token mode: UNCHANGED from current implementation
         if (!api.getIncludeCredentials()) {
             authToken.current = null;
             authTokenCreatedAt.current = null;


### PR DESCRIPTION
## Summary

Adds OpenID Connect support to the indexer-ui. Pairs with the upcoming [openrag `oidc-step-1` PR](https://github.com/linagora/openrag/pulls) which implements the backend `AUTH_MODE=oidc` flow.

When the backend runs with `AUTH_MODE=oidc`, the browser receives an `openrag_session` cookie from `/auth/callback` and it is sent with every cross-origin fetch (backed by `credentials: "include"` + permissive CORS on the backend).

## Changes

- `entrypoint.sh` / `.env.example`: expose `AUTH_MODE` in the generated `config.json`.
- `src/lib/api/index.ts`:
  - Read `AUTH_MODE` in `loadConfig()`, new helpers `getAuthMode()` / `isOidcMode()`.
  - New `authFetch()` wrapper: Bearer header in token mode; cookie credentials + auto-redirect to `${API_BASE_URL}/auth/login?next=<absolute URL>` on 401/403 in oidc mode.
  - `login()` probes `/users/info` with credentials in oidc mode (no token arg).
- `src/lib/api/indexer.ts`, `src/lib/api/dashboard.ts`: 12 direct `fetch()` calls migrated to `authFetch()`; unused `authToken` imports removed.
- `src/routes/+layout.svelte`: `onMount` branches on `isOidcMode()` — checks auth via `/users/info` and redirects to OIDC on failure; token-mode path byte-for-byte identical.
- `src/lib/components/layout/NavBar.svelte`: "Lock access" → "Logout" in oidc mode, hits `${API_BASE_URL}/auth/logout` (triggers RP-initiated logout on the backend + IdP).

## Backward compatibility

`AUTH_MODE=token` (default) behavior is strictly unchanged.

## Test plan

- [ ] `npm run build` — succeeds
- [ ] `npm run check` — no new errors (8 pre-existing)
- [ ] Token mode: login form still works with existing `AUTH_TOKEN`
- [ ] OIDC mode: browser → 302 → IdP login → callback → indexer-ui renders authenticated
- [ ] OIDC mode: `/users/info` returns 200 with the cookie
- [ ] OIDC mode: "Logout" button kills the session (backend `revoke_oidc_session_by_id`) and bounces to the IdP
- [ ] Back-channel logout from the IdP invalidates the session (verified via OpenRag backend tests)

## Draft

This PR depends on the matching openrag backend PR. Kept in draft until the backend lands and end-to-end validation passes.