### PR TITLE
fix: non-admin dashboard redirect loop in OIDC mode

### DIFF
--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -59,8 +59,9 @@ export async function authFetch(input: string, init?: RequestInit): Promise<Resp
 
     const response = await fetch(input, { ...init, headers, credentials });
 
-    // oidc auto-redirect on unauth
-    if (AUTH_MODE === "oidc" && (response.status === 401 || response.status === 403)) {
+    // oidc auto-redirect on unauth (401 only — 403 means authenticated but lacking
+    // permission, so re-login would just loop back to the same forbidden page).
+    if (AUTH_MODE === "oidc" && response.status === 401) {
         const next = encodeURIComponent(window.location.href);
         window.location.href = `${API_BASE_URL}/auth/login?next=${next}`;
         // Return a pending-forever response so callers don't see stale 401 data

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,4 +1,5 @@
 import { base } from "$app/paths";
+import type { UserInfo } from "$lib/types";
 
 // Removes the trailing slash from the base URL if it exists
 const normalizeUrl = (url: string): string => {
@@ -71,17 +72,25 @@ export async function authFetch(input: string, init?: RequestInit): Promise<Resp
     return response;
 }
 
-export async function login(authToken?: string): Promise<boolean> {
+export interface LoginResult {
+    ok: boolean;
+    // Present in OIDC mode when login succeeds: the /users/info payload
+    // fetched during the auth check. Callers can reuse it to avoid a second
+    // round-trip for the same data.
+    userInfo?: UserInfo;
+}
+
+export async function login(authToken?: string): Promise<LoginResult> {
     console.log("Trying to log in...");
 
     if (AUTH_MODE === "oidc") {
         const response = await fetch(`${API_BASE_URL}/users/info`, {
             credentials: "include",
         });
-        if (response.ok) {
-            console.log("Log in successful (oidc).");
-        }
-        return response.ok;
+        if (!response.ok) return { ok: false };
+        console.log("Log in successful (oidc).");
+        const userInfo = (await response.json()) as UserInfo;
+        return { ok: true, userInfo };
     }
 
     // token mode: existing behaviour
@@ -99,7 +108,7 @@ export async function login(authToken?: string): Promise<boolean> {
     }
 
     console.log("Log in successful.");
-    return true;
+    return { ok: true };
 }
 
 export * from "./indexer";

--- a/src/lib/components/dashboard/Header.svelte
+++ b/src/lib/components/dashboard/Header.svelte
@@ -20,24 +20,29 @@
 
     let refreshing = $state(false);
     let countdown = $state(5);
+    let tickTimeout: ReturnType<typeof setTimeout> | undefined;
 
     async function refreshActors() {
         refreshing = true;
-        dashboardData.actors = await api.fetchActors();
-        refreshing = false;
-        countdown = 5;
+        try {
+            dashboardData.actors = await api.fetchActors();
+        } catch (err) {
+            console.error("Auto-refresh fetchActors failed:", err);
+        } finally {
+            refreshing = false;
+            countdown = 5;
+        }
     }
 
     async function tick() {
         countdown -= 1;
-
         if (countdown == 0) await refreshActors();
-
-        setTimeout(tick, 1000);
+        tickTimeout = setTimeout(tick, 1000);
     }
 
     onMount(() => {
-        setTimeout(tick, 1000);
+        tickTimeout = setTimeout(tick, 1000);
+        return () => clearTimeout(tickTimeout);
     });
 </script>
 

--- a/src/lib/components/layout/Login.svelte
+++ b/src/lib/components/layout/Login.svelte
@@ -70,7 +70,7 @@
         // await new Promise((resolve) => setTimeout(resolve, 1000)); // Simulate loading delay
 
         try {
-            if (await api.login(authTokenInput.value)) {
+            if ((await api.login(authTokenInput.value)).ok) {
                 // If the Auth Token is correct, store it in a cookie, hide the login page and access the app
                 authToken.current = authTokenInput.value; // Save the Auth Token in a cookie
                 authTokenCreatedAt.current = Date.now(); // Save the creation time of the Auth Token

--- a/src/lib/components/layout/NavBar.svelte
+++ b/src/lib/components/layout/NavBar.svelte
@@ -108,17 +108,19 @@
             >
                 <FileStorage className="size-6 fill-white" />
             </a>
-            <!-- Dashboard -->
-            <a
-                href="{base}/dashboard/"
-                title={$_('nav.dashboard')}
-                class="p-2 rounded-2xl
-                {currentRoute === 'dashboard'
-                    ? 'bg-linagora-700'
-                    : 'bg-linagora-500 hover:bg-linagora-600'}"
-            >
-                <Dashboard className="size-6 fill-white" />
-            </a>
+            {#if indexerData.userInfo?.is_admin}
+                <!-- Dashboard (admin only) -->
+                <a
+                    href="{base}/dashboard/"
+                    title={$_('nav.dashboard')}
+                    class="p-2 rounded-2xl
+                    {currentRoute === 'dashboard'
+                        ? 'bg-linagora-700'
+                        : 'bg-linagora-500 hover:bg-linagora-600'}"
+                >
+                    <Dashboard className="size-6 fill-white" />
+                </a>
+            {/if}
         </div>
 
         {#if api.getIncludeCredentials() || api.isOidcMode()}
@@ -219,22 +221,24 @@
                     ></div>
                 {/if}
             </a>
-            <!-- Dashboard -->
-            <a
-                href="{base}/dashboard"
-                class="relative p-2 flex items-center space-x-2 rounded-2xl
-                {currentRoute === 'dashboard'
-                    ? 'bg-linagora-700'
-                    : 'bg-linagora-500 hover:bg-linagora-600'}"
-            >
-                <Dashboard className="size-6 fill-white" />
-                <span> {$_('nav.dashboard')} </span>
-                {#if currentRoute === "dashboard"}
-                    <div
-                        class="absolute right-3 size-1 rounded-full bg-white"
-                    ></div>
-                {/if}
-            </a>
+            {#if indexerData.userInfo?.is_admin}
+                <!-- Dashboard (admin only) -->
+                <a
+                    href="{base}/dashboard"
+                    class="relative p-2 flex items-center space-x-2 rounded-2xl
+                    {currentRoute === 'dashboard'
+                        ? 'bg-linagora-700'
+                        : 'bg-linagora-500 hover:bg-linagora-600'}"
+                >
+                    <Dashboard className="size-6 fill-white" />
+                    <span> {$_('nav.dashboard')} </span>
+                    {#if currentRoute === "dashboard"}
+                        <div
+                            class="absolute right-3 size-1 rounded-full bg-white"
+                        ></div>
+                    {/if}
+                </a>
+            {/if}
         </div>
 
         {#if api.getIncludeCredentials() || api.isOidcMode()}

--- a/src/routes/(home)/+page.svelte
+++ b/src/routes/(home)/+page.svelte
@@ -5,6 +5,8 @@
     import FileStorage from "$lib/icons/FileStorage.svelte";
     import Dashboard from "$lib/icons/Dashboard.svelte";
     import { _ } from "svelte-i18n";
+    // State
+    import { indexerData } from "$lib/states.svelte";
 </script>
 
 <div class="grow px-12 pt-5 pb-8 h-full flex flex-col overflow-y-scroll">
@@ -43,20 +45,22 @@
                 {$_('home.go_to_indexer')}
             </span>
         </a>
-        <!-- Dashboard -->
-        <a
-            href="{base}/dashboard"
-            aria-label="Link to dashboard"
-            class="h-72 w-60 p-6 flex flex-col items-center
-            rounded-3xl border border-slate-200 shadow-lg cursor-pointer
-            hover:shadow-xl hover:bg-slate-50"
-        >
-            <Dashboard className="size-16 fill-linagora-500 mb-4" />
-            <span class="text-center font-medium"> {$_('home.dashboard_card_description')} </span>
-            <div class="grow"></div>
-            <span class="bg-linagora-500 px-4 py-2 rounded-2xl text-white font-medium hover:bg-linagora-600">
-                {$_('home.go_to_dashboard')}
-            </span>
-        </a>
+        {#if indexerData.userInfo?.is_admin}
+            <!-- Dashboard (admin only) -->
+            <a
+                href="{base}/dashboard"
+                aria-label="Link to dashboard"
+                class="h-72 w-60 p-6 flex flex-col items-center
+                rounded-3xl border border-slate-200 shadow-lg cursor-pointer
+                hover:shadow-xl hover:bg-slate-50"
+            >
+                <Dashboard className="size-16 fill-linagora-500 mb-4" />
+                <span class="text-center font-medium"> {$_('home.dashboard_card_description')} </span>
+                <div class="grow"></div>
+                <span class="bg-linagora-500 px-4 py-2 rounded-2xl text-white font-medium hover:bg-linagora-600">
+                    {$_('home.go_to_dashboard')}
+                </span>
+            </a>
+        {/if}
     </div>
 </div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -60,12 +60,14 @@
             // oidc mode: no login screen, check auth via /users/info
             ui.showLoginPage = false; // never show the password form
             try {
-                const ok = await api.login(); // checks /users/info with credentials: "include"
-                if (!ok) {
+                const result = await api.login(); // checks /users/info with credentials: "include"
+                if (!result.ok) {
                     const next = encodeURIComponent(window.location.href);
                     window.location.href = `${api.getApiBaseUrl()}/auth/login?next=${next}`;
                     return; // stop here, browser is navigating
                 }
+                // Reuse the userInfo that login() already fetched.
+                if (result.userInfo) indexerData.userInfo = result.userInfo;
             } catch {
                 const next = encodeURIComponent(window.location.href);
                 window.location.href = `${api.getApiBaseUrl()}/auth/login?next=${next}`;
@@ -96,7 +98,7 @@
         }
 
         // Initial check to see if the user is already logged in
-        if (authToken.current && (await api.login(authToken.current))) {
+        if (authToken.current && (await api.login(authToken.current)).ok) {
             ui.showLoginPage = false;
             await loadUserInfo();
         } else if (

--- a/src/routes/api/config/+server.ts
+++ b/src/routes/api/config/+server.ts
@@ -4,8 +4,16 @@ import path from 'path';
 
 export const GET: RequestHandler = async () => {
     const configPath = path.resolve(process.cwd(), 'config.json');
-    const raw = fs.readFileSync(configPath, 'utf-8');
-    const config = JSON.parse(raw);
+    let config: Record<string, unknown>;
+    if (fs.existsSync(configPath)) {
+        config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    } else {
+        config = {
+            API_BASE_URL: process.env.API_BASE_URL ?? 'http://localhost:8000',
+            INCLUDE_CREDENTIALS: process.env.INCLUDE_CREDENTIALS === 'true',
+            AUTH_MODE: process.env.AUTH_MODE ?? 'token'
+        };
+    }
     return new Response(JSON.stringify(config), {
         headers: { 'Content-Type': 'application/json' }
     });

--- a/src/routes/dashboard/+layout.svelte
+++ b/src/routes/dashboard/+layout.svelte
@@ -6,13 +6,14 @@
     import * as api from "$lib/api";
 
     // States
-    import { ui, dashboardData } from "$lib/states.svelte";
+    import { ui, dashboardData, indexerData } from "$lib/states.svelte";
 
     // Components
     import Header from "$lib/components/dashboard/Header.svelte";
 
     // Properties
     let { children } = $props();
+    let loadError = $state<string | null>(null);
 
     /**
      * Function to refresh tasks periodically.
@@ -46,8 +47,25 @@
     async function handleRouting() {
         if (ui.showLoginPage) return;
 
-        // Load actors
-        dashboardData.actors = await api.fetchActors();
+        // /dashboard is admin-only. If we already know the user isn't admin,
+        // bounce them home instead of firing a request that will 403.
+        if (indexerData.userInfo && !indexerData.userInfo.is_admin) {
+            goto(`${base}/`);
+            return;
+        }
+
+        // Load actors. On 403 the backend has told us this user can't see the
+        // dashboard — show an access-denied state instead of a blank page.
+        loadError = null;
+        try {
+            dashboardData.actors = await api.fetchActors();
+        } catch (err) {
+            loadError =
+                err instanceof Error && err.message.includes("403")
+                    ? "You don't have permission to view the dashboard."
+                    : "Failed to load actors. Please try again later.";
+            console.error("fetchActors failed:", err);
+        }
 
         // if (page.route.id === "/indexer") {
         //     // Reset navigation states
@@ -97,5 +115,12 @@
 <Header />
 
 <div class="grow m-4 h-full overflow-scroll rounded-2xl border border-slate-200 bg-white shadow-sm">
-    {@render children()}
+    {#if loadError}
+        <div class="flex h-full flex-col items-center justify-center p-8 text-center space-y-2">
+            <span class="text-lg font-medium text-slate-700">{loadError}</span>
+            <a href="{base}/" class="text-linagora-600 hover:underline">Back to home</a>
+        </div>
+    {:else}
+        {@render children()}
+    {/if}
 </div>

--- a/src/routes/indexer/+layout.svelte
+++ b/src/routes/indexer/+layout.svelte
@@ -63,16 +63,8 @@
     async function handleRouting() {
         if (ui.showLoginPage) return;
 
-        // Load partitions and user info
+        // Load partitions (userInfo is fetched by the root layout).
         indexerData.partitions = await api.fetchPartitions();
-        
-        // Fetch user info (for quota display)
-        try {
-            indexerData.userInfo = await api.fetchUserInfo();
-            refreshUserInfoInterval = setInterval(refreshUserInfo, 10000); // Refresh every 10 seconds
-        } catch (error) {
-            console.error("Failed to fetch user info:", error);
-        }
 
         if (page.route.id === "/indexer") {
             // Reset navigation states
@@ -127,9 +119,9 @@
     }
 
     onMount(() => {
+        refreshUserInfoInterval = setInterval(refreshUserInfo, 10000); // Refresh every 10 seconds
         return () => {
             console.log("Leaving indexer, clearing intervals.");
-            // Clear any intervals or timeouts here if needed
             clearInterval(refreshTasksInterval);
             clearInterval(refreshUserInfoInterval);
         };

--- a/tests/mock-backend.mjs
+++ b/tests/mock-backend.mjs
@@ -1,0 +1,81 @@
+// Mock OpenRAG backend for testing the non-admin dashboard flow.
+// Simulates: OIDC-mode backend, valid session, user.is_admin = false.
+// Run with: node tests/mock-backend.mjs
+
+import http from 'node:http';
+
+const PORT = 8001;
+const ORIGIN = 'http://localhost:5173';
+
+const USER_INFO = {
+    id: 'non-admin-1',
+    display_name: 'Non Admin',
+    is_admin: false,
+    memberships: [],
+    file_count: 0,
+    pending_files: 0,
+    total_files: 0,
+    file_quota: -1
+};
+
+function cors(res) {
+    res.setHeader('Access-Control-Allow-Origin', ORIGIN);
+    res.setHeader('Access-Control-Allow-Credentials', 'true');
+    res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+}
+
+const server = http.createServer((req, res) => {
+    cors(res);
+    const url = new URL(req.url, `http://localhost:${PORT}`);
+    const path = url.pathname;
+    console.log(`[mock] ${req.method} ${path}${url.search}`);
+
+    if (req.method === 'OPTIONS') {
+        res.writeHead(204);
+        res.end();
+        return;
+    }
+
+    // Simulated OIDC re-auth: always succeeds, bounces back to `next`.
+    // If the 403 fix is broken, the frontend will keep hitting this in a loop.
+    if (path === '/auth/login') {
+        const next = url.searchParams.get('next') ?? ORIGIN;
+        res.writeHead(302, { Location: next });
+        res.end();
+        return;
+    }
+
+    if (path === '/users/info') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(USER_INFO));
+        return;
+    }
+
+    if (path === '/actors/') {
+        res.writeHead(403, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ detail: 'Admin rights required' }));
+        return;
+    }
+
+    if (path === '/partition/') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ partitions: [] }));
+        return;
+    }
+
+    if (path === '/health_check') {
+        res.writeHead(200);
+        res.end('ok');
+        return;
+    }
+
+    res.writeHead(404);
+    res.end();
+});
+
+server.listen(PORT, () => {
+    console.log(`[mock] OpenRAG mock backend on http://localhost:${PORT}`);
+    console.log(`[mock] CORS origin: ${ORIGIN}`);
+    console.log(`[mock] User: ${USER_INFO.display_name} (is_admin=${USER_INFO.is_admin})`);
+});


### PR DESCRIPTION
## Summary

Fixes an infinite redirect loop hit in production: a non-admin user
loading `/dashboard` in OIDC mode was bounced through
`/actors/ 403 → /auth/login 302 → /dashboard → ...` indefinitely.

Root cause: `authFetch` treated 401 and 403 identically and redirected
both to the login endpoint. 403 means "authenticated but unauthorized",
so re-authenticating always succeeds and redirects back to the same
forbidden page. Commit `fix(auth): restrict OIDC login redirect to 401
only` is the minimum fix.

The rest of the PR is defense-in-depth and cleanup uncovered during
testing:

- Hoist `userInfo` fetch to the root layout so `is_admin` is available
  everywhere (and dedupe the `/users/info` call by reusing what
  `login()` already fetched in OIDC mode).
- Hide the Dashboard nav link and the home-page "Go to dashboard" card
  when `!is_admin`.
- Guard `/dashboard` route: non-admins redirect to home; a 403 that
  slips through renders "You don't have permission" instead of a blank
  page + unhandled rejection.
- Clear `Header.svelte`'s 5s auto-refresh `setTimeout` on unmount (it
  was leaking and firing `fetchActors` after the user left the page).
- Dev ergonomics: `/api/config` now falls back to env vars when
  `config.json` is absent, so `npm run dev` doesn't hang on a missing
  file that only Docker's `entrypoint.sh` creates.
- Add `mock-backend.mjs` — zero-dep Node server that reproduces the
  non-admin scenario locally; usable as a regression test.

## Test plan

Automated reproduction:

1. `node mock-backend.mjs` (serves non-admin OIDC backend on :8001)
2. Set `config.json` to `{ "API_BASE_URL": "http://localhost:8001", "INCLUDE_CREDENTIALS": true, "AUTH_MODE": "oidc" }`
3. `npm run dev`, open http://localhost:5173/

Verified manually via Chrome DevTools Network tab:

- [x] Non-admin on `/` — NavBar has no Dashboard link; home page has no Dashboard card.
- [x] Direct navigation to `/dashboard` — bounced to home before any fetch fires.
- [x] Bypassing guards (flip mock `is_admin` to true so the layout fires `fetchActors` → 403) — UI shows "You don't have permission", no `/auth/login` redirect, no loop.
- [x] Regression check: reverting the `authFetch` 401-only change reproduces the loop (two complete cycles in ~3 seconds) in the mock. Restoring the fix breaks the loop.
- [x] `npm run check` — no new type errors (11 pre-existing failures unrelated to this PR).

## Follow-ups not in this PR

- `src/lib/types/user.ts:15` has `memberships: ListFormat` with
  `ListFormat` imported from `typescript` — almost certainly meant
  `string[]`.
- Pre-existing `@types/node` missing — causes `process`, `fs`, `path`
  to type-fail in server routes.
  
  For non-admin users, the dashboard does not show up anymore 
<img width="262" height="247" alt="image" src="https://github.com/user-attachments/assets/0575be1c-95ad-4374-8196-5ca7f2dd0ae5" />

  
