### PR TITLE
feat(users): add button to regenerate the current user's API token

### DIFF
--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -103,3 +103,4 @@ export async function login(authToken?: string): Promise<boolean> {
 
 export * from "./indexer";
 export * from "./dashboard";
+export * from "./users";

--- a/src/lib/api/users.ts
+++ b/src/lib/api/users.ts
@@ -1,0 +1,28 @@
+// Base URL and auth helpers
+import { authFetch, getApiBaseUrl } from "./index";
+
+/**
+ * Regenerates the API token of a user.
+ *
+ * The caller must be either the owner of the account (`user_id` matches the
+ * authenticated user) or an admin. The previous token is invalidated
+ * immediately and the new one is returned in cleartext — the backend only
+ * stores its hash, so the value is shown exactly once.
+ */
+export const regenerateUserToken = async (user_id: number): Promise<string> => {
+    console.log(`Regenerating API token for user ${user_id}...`);
+    const response = await authFetch(
+        `${getApiBaseUrl()}/users/${user_id}/regenerate_token`,
+        { method: "POST" }
+    );
+
+    if (!response.ok) {
+        throw new Error(
+            `Failed to regenerate token: ${response.status} ${response.statusText}`
+        );
+    }
+
+    const data = await response.json();
+    console.log("API token regenerated.");
+    return data.token as string;
+};

--- a/src/lib/components/layout/Login.svelte
+++ b/src/lib/components/layout/Login.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     // Import states
-    import { ui } from "$lib/states.svelte";
+    import { ui, indexerData } from "$lib/states.svelte";
     import { authToken, authTokenCreatedAt } from "$lib/persisted.svelte";
 
     // Import icons
@@ -73,6 +73,11 @@
                 // If the Auth Token is correct, store it in a cookie, hide the login page and access the app
                 authToken.current = authTokenInput.value; // Save the Auth Token in a cookie
                 authTokenCreatedAt.current = Date.now(); // Save the creation time of the Auth Token
+                try {
+                    indexerData.userInfo = await api.fetchUserInfo();
+                } catch (err) {
+                    console.error("Failed to fetch user info after login:", err);
+                }
                 loading = false;
                 ui.showLoginPage = false;
             } else throw "Login failed.";

--- a/src/lib/components/layout/NavBar.svelte
+++ b/src/lib/components/layout/NavBar.svelte
@@ -8,6 +8,12 @@
     import { navbarCollapsed } from "$lib/persisted.svelte";
     import { authToken, authTokenCreatedAt } from "$lib/persisted.svelte";
 
+    // States
+    import { indexerData } from "$lib/states.svelte";
+
+    // Components
+    import RegenerateTokenModal from "$lib/components/layout/RegenerateTokenModal.svelte";
+
     // Icons
     import ChevronDown from "$lib/icons/ChevronDown.svelte";
     import Dashboard from "$lib/icons/Dashboard.svelte";
@@ -15,11 +21,21 @@
     import Home from "$lib/icons/Home.svelte";
     import OpenRAG from "$lib/icons/OpenRAG.svelte";
     import Lock from "$lib/icons/Lock.svelte";
+    import Key from "$lib/icons/Key.svelte";
 
     let currentRoute: string = $state("");
+    let showRegenerateModal = $state(false);
 
     function toggleCollapse() {
         navbarCollapsed.current = !navbarCollapsed.current;
+    }
+
+    function openRegenerateModal() {
+        showRegenerateModal = true;
+    }
+
+    function closeRegenerateModal() {
+        showRegenerateModal = false;
     }
 
     function handleLogout() {
@@ -106,6 +122,20 @@
 
         {#if api.getIncludeCredentials() || api.isOidcMode()}
             <div class="h-px w-8 mt-4 mb-3 bg-linagora-600"></div>
+
+            <!-- Regenerate API token -->
+            {#if indexerData.userInfo}
+                <button
+                    title="Regenerate API token"
+                    class="cursor-pointer group rounded-2xl p-2 font-medium text-linagora-900
+                hover:bg-linagora-600 hover:text-linagora-950"
+                    onclick={openRegenerateModal}
+                >
+                    <Key
+                        className="size-6 fill-linagora-900 group-hover:fill-linagora-950"
+                    />
+                </button>
+            {/if}
 
             <!-- Lock access / Logout -->
             <button
@@ -209,6 +239,20 @@
         {#if api.getIncludeCredentials() || api.isOidcMode()}
             <div class="h-px mt-4 mb-3 bg-linagora-600"></div>
 
+            <!-- Regenerate API token -->
+            {#if indexerData.userInfo}
+                <button
+                    class="cursor-pointer group flex items-center gap-2 rounded-2xl p-2 font-medium text-linagora-900
+                hover:bg-linagora-600 hover:text-linagora-950"
+                    onclick={openRegenerateModal}
+                >
+                    <Key
+                        className="size-6 fill-linagora-900 group-hover:fill-linagora-950"
+                    />
+                    Regenerate API token
+                </button>
+            {/if}
+
             <!-- Lock access / Logout -->
             <button
                 class="cursor-pointer group flex items-center gap-2 rounded-2xl p-2 font-medium text-linagora-900
@@ -237,4 +281,8 @@
             <ChevronDown className="rotate-90 stroke-black stroke-3 size-3" />
         </button>
     </div>
+{/if}
+
+{#if showRegenerateModal}
+    <RegenerateTokenModal onClose={closeRegenerateModal} />
 {/if}

--- a/src/lib/components/layout/RegenerateTokenModal.svelte
+++ b/src/lib/components/layout/RegenerateTokenModal.svelte
@@ -1,0 +1,210 @@
+<script lang="ts">
+    /**
+     * Modal that lets the authenticated user regenerate their own API token.
+     *
+     * The previous token is invalidated as soon as the new one is returned by
+     * the backend, so we display the new token exactly once with a copy button
+     * and a strong warning. In token mode we also update the browser-stored
+     * auth token so the user is not locked out of the UI.
+     */
+
+    import { onMount } from "svelte";
+    import * as api from "$lib/api";
+    import { authToken, authTokenCreatedAt } from "$lib/persisted.svelte";
+    import { indexerData } from "$lib/states.svelte";
+
+    // Icons
+    import Close from "$lib/icons/Close.svelte";
+    import Key from "$lib/icons/Key.svelte";
+    import Copy from "$lib/icons/Copy.svelte";
+    import PartialCircle from "$lib/icons/PartialCircle.svelte";
+
+    let { onClose }: { onClose: () => void } = $props();
+
+    type Step = "confirm" | "loading" | "success" | "error";
+    let step: Step = $state("confirm");
+    let newToken: string | null = $state(null);
+    let errorMessage: string = $state("");
+    let copied = $state(false);
+
+    async function regenerate() {
+        const user = indexerData.userInfo;
+        if (!user) {
+            errorMessage = "User information is not loaded yet.";
+            step = "error";
+            return;
+        }
+
+        step = "loading";
+        try {
+            const token = await api.regenerateUserToken(Number(user.id));
+            newToken = token;
+
+            // Token-mode sessions authenticate via the stored auth token; replace
+            // it so the UI keeps working with the freshly generated value. In
+            // oidc mode the UI session lives in a cookie, so we leave it alone.
+            if (!api.isOidcMode() && authToken.current) {
+                authToken.current = token;
+                authTokenCreatedAt.current = Date.now();
+            }
+
+            step = "success";
+        } catch (err) {
+            console.error("Token regeneration failed:", err);
+            errorMessage =
+                err instanceof Error ? err.message : "Unknown error while regenerating the token.";
+            step = "error";
+        }
+    }
+
+    async function copyToken() {
+        if (!newToken) return;
+        try {
+            await navigator.clipboard.writeText(newToken);
+            copied = true;
+            setTimeout(() => (copied = false), 2000);
+        } catch (err) {
+            console.error("Clipboard write failed:", err);
+        }
+    }
+
+    function handleKey(event: KeyboardEvent) {
+        if (event.key === "Escape") onClose();
+    }
+
+    onMount(() => {
+        window.addEventListener("keydown", handleKey);
+        return () => window.removeEventListener("keydown", handleKey);
+    });
+</script>
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<div
+    class="fixed inset-0 z-100 h-screen w-screen bg-slate-500/20 backdrop-blur-xs"
+    onclick={onClose}
+    role="dialog"
+    tabindex="-1"
+    aria-labelledby="regenerate-token-title"
+></div>
+
+<div
+    class="fixed top-1/2 left-1/2 z-100 -translate-x-1/2 -translate-y-1/2
+    w-[32rem] max-w-[90vw] max-h-[90vh] flex flex-col overflow-hidden
+    rounded-3xl bg-white shadow-lg"
+>
+    <div class="flex items-center justify-between p-6 pb-4">
+        <h1
+            id="regenerate-token-title"
+            class="flex items-center gap-2 text-xl font-semibold"
+        >
+            <Key className="size-6 fill-linagora-500" />
+            Regenerate API token
+        </h1>
+        <button
+            onclick={onClose}
+            class="flex items-center justify-center"
+            aria-label="Close regenerate token modal"
+        >
+            <Close
+                className="size-6 stroke-3 rounded-full p-1 hover:bg-slate-100 cursor-pointer"
+            />
+        </button>
+    </div>
+
+    <div class="px-6 pb-6 flex flex-col space-y-4 overflow-y-auto">
+        {#if step === "confirm"}
+            <p class="text-slate-700">
+                A new API token will be generated for your account. The
+                <strong>current token will stop working immediately</strong>,
+                and every integration that relies on it will need to be
+                updated.
+            </p>
+            <p class="text-sm text-slate-500">
+                The new token is shown exactly once — it is stored only as a
+                hash in the database, so make sure to save it before closing
+                this dialog.
+            </p>
+
+            <div class="flex justify-end gap-3 pt-2">
+                <button
+                    class="cursor-pointer rounded-2xl border border-slate-200 px-4 py-2 font-medium text-slate-500 hover:bg-slate-50"
+                    onclick={onClose}
+                >
+                    Cancel
+                </button>
+                <button
+                    class="cursor-pointer rounded-2xl border-none bg-linagora-500 px-4 py-2 font-semibold text-white hover:bg-linagora-600"
+                    onclick={regenerate}
+                >
+                    Regenerate token
+                </button>
+            </div>
+        {:else if step === "loading"}
+            <div class="flex flex-col items-center justify-center py-8 gap-3">
+                <PartialCircle
+                    className="size-8 animate-spin fill-linagora-500"
+                />
+                <span class="text-slate-500">Generating new token...</span>
+            </div>
+        {:else if step === "success" && newToken}
+            <div
+                class="rounded-2xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800"
+            >
+                Copy this token and store it safely — it will not be shown
+                again.
+            </div>
+
+            <div class="flex flex-col gap-2">
+                <label for="new-token" class="text-sm font-medium text-slate-600">
+                    Your new API token
+                </label>
+                <div class="flex items-stretch gap-2">
+                    <input
+                        id="new-token"
+                        class="grow rounded-2xl border border-slate-200 bg-slate-50 px-4 py-2 font-mono text-sm text-slate-800"
+                        readonly
+                        value={newToken}
+                        onclick={(e) => (e.target as HTMLInputElement).select()}
+                    />
+                    <button
+                        onclick={copyToken}
+                        class="flex items-center gap-2 rounded-2xl border border-slate-200 px-3 py-2 font-medium text-slate-700 hover:bg-slate-50 cursor-pointer"
+                        title="Copy token to clipboard"
+                    >
+                        <Copy className="size-5 fill-slate-600" />
+                        {copied ? "Copied!" : "Copy"}
+                    </button>
+                </div>
+            </div>
+
+            <div class="flex justify-end pt-2">
+                <button
+                    class="cursor-pointer rounded-2xl border-none bg-linagora-500 px-4 py-2 font-semibold text-white hover:bg-linagora-600"
+                    onclick={onClose}
+                >
+                    Done
+                </button>
+            </div>
+        {:else if step === "error"}
+            <div
+                class="rounded-2xl border border-red-200 bg-red-50 p-3 text-sm text-red-700"
+            >
+                {errorMessage}
+            </div>
+            <div class="flex justify-end gap-3 pt-2">
+                <button
+                    class="cursor-pointer rounded-2xl border border-slate-200 px-4 py-2 font-medium text-slate-500 hover:bg-slate-50"
+                    onclick={onClose}
+                >
+                    Close
+                </button>
+                <button
+                    class="cursor-pointer rounded-2xl border-none bg-linagora-500 px-4 py-2 font-semibold text-white hover:bg-linagora-600"
+                    onclick={() => (step = "confirm")}
+                >
+                    Retry
+                </button>
+            </div>
+        {/if}
+    </div>
+</div>

--- a/src/lib/icons/Copy.svelte
+++ b/src/lib/icons/Copy.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+    // Properties
+    let { className = "size-5 stroke-3" }: { className?: string } = $props();
+</script>
+
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    height="24px"
+    viewBox="0 -960 960 960"
+    width="24px"
+    fill="inherit"
+    class={className}
+>
+    <path
+        d="M360-240q-33 0-56.5-23.5T280-320v-480q0-33 23.5-56.5T360-880h360q33 0 56.5 23.5T800-800v480q0 33-23.5 56.5T720-240H360Zm0-80h360v-480H360v480ZM200-80q-33 0-56.5-23.5T120-160v-560h80v560h440v80H200Zm160-240v-480 480Z"
+    />
+</svg>

--- a/src/lib/icons/Key.svelte
+++ b/src/lib/icons/Key.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+    // Properties
+    let { className = "size-5 stroke-3" }: { className?: string } = $props();
+</script>
+
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    height="24px"
+    viewBox="0 -960 960 960"
+    width="24px"
+    fill="inherit"
+    class={className}
+>
+    <path
+        d="M280-400q-33 0-56.5-23.5T200-480q0-33 23.5-56.5T280-560q33 0 56.5 23.5T360-480q0 33-23.5 56.5T280-400Zm0 160q-100 0-170-70T40-480q0-100 70-170t170-70q67 0 121.5 33t86.5 87h352l120 120-180 180-80-60-80 60-85-60h-47q-32 54-86.5 87T280-240Zm0-80q56 0 98.5-34t56.5-86h125l58 41 82-61 71 55 75-75-40-40H435q-14-52-56.5-86T280-640q-66 0-113 47t-47 113q0 66 47 113t113 47Z"
+    />
+</svg>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -16,7 +16,7 @@
     import * as api from "$lib/api";
 
     // States, persisted states, and cookies
-    import { ui } from "$lib/states.svelte";
+    import { ui, indexerData } from "$lib/states.svelte";
     import { authToken, authTokenCreatedAt } from "$lib/persisted.svelte";
 
     // Components
@@ -31,6 +31,19 @@
 
     // Reactive variables
     let loading = $state(true);
+
+    /**
+     * Fetch current user info as soon as the session is ready. Stored in the
+     * global `indexerData` state so the NavBar (and any other component) can
+     * use it regardless of the current route.
+     */
+    async function loadUserInfo() {
+        try {
+            indexerData.userInfo = await api.fetchUserInfo();
+        } catch (error) {
+            console.error("Failed to fetch user info:", error);
+        }
+    }
 
     // Run when the component initializes for the first time
     onMount(async () => {
@@ -51,6 +64,7 @@
                 window.location.href = `${api.getApiBaseUrl()}/auth/login?next=${next}`;
                 return;
             }
+            await loadUserInfo();
             loading = false;
             return;
         }
@@ -60,6 +74,7 @@
             authToken.current = null;
             authTokenCreatedAt.current = null;
             ui.showLoginPage = false;
+            await loadUserInfo();
             loading = false;
             return;
         }
@@ -76,6 +91,7 @@
         // Initial check to see if the user is already logged in
         if (authToken.current && (await api.login(authToken.current))) {
             ui.showLoginPage = false;
+            await loadUserInfo();
         } else if (
             page.route.id !== "/" &&
             page.route.id !== "/indexer" &&


### PR DESCRIPTION
## Summary

- Adds a **key** icon in the NavBar (shown in modes where the UI authenticates — `INCLUDE_CREDENTIALS` or OIDC) that opens a confirmation modal to regenerate the current user's API token.
- Calls `POST /users/{id}/regenerate_token`, which is tightened to admin-or-self in the companion backend PR: **linagora/openrag#311**.
- Displays the new token exactly once with a copy-to-clipboard button and a warning that the previous token has been invalidated (the backend only stores a hash).
- In token mode the browser-stored auth token is replaced with the new one so the active UI session is not broken. In OIDC mode the UI session is cookie-based and the displayed token is only useful for programmatic API access.
- User info (/users/info) is now fetched at the root layout (and after a token-mode login) instead of only inside the indexer layout, so the button is available on every route.

## Companion PR

- Backend: linagora/openrag#311 — enforces admin-or-self on /users/{id}/regenerate_token and bumps this submodule. This UI PR requires that backend change to get proper 403s for non-self, non-admin callers.

## Test plan

- [ ] With `INCLUDE_CREDENTIALS=true` (token mode): log in, click the key icon, confirm, copy the new token. The UI must keep working without re-login and the new token must authenticate on /users/info.
- [ ] With `OIDC` mode: confirm the button appears, regenerating yields a new token that authenticates against the API via `Authorization: Bearer`.
- [ ] With `INCLUDE_CREDENTIALS=false` (no-auth mode): the button is hidden alongside the existing "Lock access" button.
- [ ] Escape key and clicking the backdrop both dismiss the modal.
- [ ] Existing regressions (indexer, dashboard, partitions, quota header) still work.