### PR TITLE
chore(env): restore previous env var naming in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
-VITE_API_BASE_URL= # Base URL of the API, e.g., https://example.com/api
-VITE_INCLUDE_CREDENTIALS=false # Set to true to enable login screen and include credentials in requests, or false to disable it
+API_BASE_URL= # Base URL of the API, e.g., https://example.com/api
+INCLUDE_CREDENTIALS=false # Set to true to enable login screen and include credentials in requests, or false to disable it
 AUTH_MODE=token # Authentication mode: "token" (default, legacy Bearer flow) or "oidc" (OpenID Connect cookie-based flow)


### PR DESCRIPTION
Updating .env.example to drop the VITE_ prefix, which followed an old naming convention no longer used in the codebase.